### PR TITLE
fix crash when executed on arm64

### DIFF
--- a/uup-converter-wimlib/convert-UUP.cmd
+++ b/uup-converter-wimlib/convert-UUP.cmd
@@ -76,6 +76,10 @@ if /i %PROCESSOR_ARCHITECTURE%==x86 (if defined PROCESSOR_ARCHITEW6432 (
   set "xDS=bin"
   )
 )
+if /i %PROCESSOR_ARCHITECTURE%==arm64 (
+  set "xOS=x86"
+  set "xDS=bin"
+)
 set "Path=%xDS%;%SysPath%;%SystemRoot%;%SysPath%\Wbem;%SysPath%\WindowsPowerShell\v1.0\"
 set "_err===== ERROR ===="
 


### PR DESCRIPTION
When this script is executed on a machine running "windows on arm" it crashes, cause it tries to execute the x64 binary "wimlib-imagex.exe". At the moment windows 10 is only capable of emulating x86 binaries on arm.

By detecting the cpu architecture and switching to the x86 binaries the script works fine.