### PR TITLE
OfficeScrubber: Replace HKCU to a method to delete the registry in all users

### DIFF
--- a/OfficeScrubber/OfficeScrubber.cmd
+++ b/OfficeScrubber/OfficeScrubber.cmd
@@ -600,9 +600,19 @@ if exist "%ProgramFiles(x86)%\Microsoft Office\Office%1\*.dll" set _O%1MSI=1
 goto :eof
 
 :officeREG
-reg delete HKCU\Software\Microsoft\Office\%1.0 /f
-reg delete HKCU\Software\Policies\Microsoft\Office\%1.0 /f
-reg delete HKCU\Software\Policies\Microsoft\Cloud\Office\%1.0 /f
+for /f "tokens=1" %%a in ('reg query "HKU" %_Nul6%') do (
+   reg delete %%a\Software\Microsoft\Office\%1.0 /f
+   reg delete %%a\Software\Policies\Microsoft\Office\%1.0 /f
+   reg delete %%a\Software\Policies\Microsoft\Cloud\Office\%1.0 /f
+)
+for /f "skip=2 tokens=2*" %%a in ('reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList" /s /v ProfileImagePath ^| findstr /i "ProfileImagePath" %_Nul6%') do (
+   reg load HKU\TempHive "%%b\NTUSER.DAT" %_Nul2% && (
+      reg delete HKU\TempHive\Software\Microsoft\Office\%1.0 /f
+      reg delete HKU\TempHive\Software\Policies\Microsoft\Office\%1.0 /f
+      reg delete HKU\TempHive\Software\Policies\Microsoft\Cloud\Office\%1.0 /f
+      reg unload HKU\TempHive %_Nul2%
+   )
+)
 reg delete HKLM\SOFTWARE\Microsoft\Office\%1.0 /f
 reg delete HKLM\SOFTWARE\Policies\Microsoft\Office\%1.0 /f
 reg delete HKLM\SOFTWARE\Microsoft\Office\%1.0 /f /reg:32


### PR DESCRIPTION
This replaces a method used to delete the Office registry from HKCU, which deletes the specified registries for all users on the computer.

This is particularly advantageous for terminal servers, as it not only deletes the specified registries for the user being executed (current user), but also for all other users, both logged in and unlogged in.

I tested it on a VM with three users, two of whom had already launched Office applications, and only one of whom was logged in. This worked in my case.